### PR TITLE
Reduce min height prop

### DIFF
--- a/src/editor.vue
+++ b/src/editor.vue
@@ -33,7 +33,7 @@
                 type: Number,
                 default: 300,
                 validator (val) {
-                    return val >= 300
+                    return val >= 100
                 }
             },
             zIndex: {


### PR DESCRIPTION
I found the `300px` height to import (for instance, comment area), `100px` seems more like it, nah ?