### PR TITLE
Update vue-html5-editor.js

### DIFF
--- a/dist/vue-html5-editor.js
+++ b/dist/vue-html5-editor.js
@@ -396,7 +396,11 @@ var dashboard$3 = {
             var config = this.$options.module.config;
             var formData = new FormData();
             formData.append(config.fieldName, file);
-
+		//支持传递更多的表单参数给服务端
+            for(var name in config.obj){
+            	 formData.append(name, config.obj[i]);
+            }
+		
             var xhr = new XMLHttpRequest();
 
             xhr.onprogress = function (e) {


### PR DESCRIPTION
在图片上传过程中 支持传递更多的表达参数给服务器
 image: {
	        // 后端图片上传的地址，如果为空，默认转图片为base64
	        // Url of the server-side,default null and convert image to base64
	        server: "",
	        fieldName: "resources",
	        compress: true,
               //附加的表单参数
	        obj:{'storageType': 'UNITPHOTO','objectType': 'UNITPHOTO'},
	        uploadHandler(responseText){
	          
	        }
	  }