### PR TITLE
Improvement: Status cod 201 should be allowed

### DIFF
--- a/src/modules/image/dashboard.js
+++ b/src/modules/image/dashboard.js
@@ -151,7 +151,7 @@ export default {
             }
 
             xhr.onload = () => {
-                if (xhr.status !== 200) {
+                if (xhr.status >= 300) {
                     this.setUploadError(`request error,code ${xhr.status}`)
                     return
                 }


### PR DESCRIPTION
Some RESTful backend interface returns status code 201 for successful created requests.

So 201-299 should be considered as success, not only 200.