### PR TITLE
修复双向绑定content

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -44,6 +44,7 @@ export default {
             if (val !== content) {
                 this.$refs.content.innerHTML = val
             }
+            this.$emit('update:content', val)
         },
         fullScreen(val){
             const component = this


### PR DESCRIPTION
新版本Vue使用:content.sync来进行双向绑定必须在
组件下watch加入一下代码

content(val) {
            const content = this.$refs.content.innerHTML
            if (val !== content) {
                this.$refs.content.innerHTML = val
                this.$emit('update:content', val)
            }
        }