### PR TITLE
fixed #116

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -159,7 +159,7 @@ export default {
         const content = this.$refs.content
         content.innerHTML = this.content
         content.addEventListener('mouseup', this.saveCurrentRange, false)
-        content.addEventListener('keyup', () => {
+        content.addEventListener('input', () => {
             this.$emit('change', content.innerHTML)
             this.saveCurrentRange()
         }, false)


### PR DESCRIPTION
鼠标粘贴的内容无法被 keyup 事件监听，改用 input 事件可兼容包括键盘输入、鼠标粘贴情况下 content 内容的变化。